### PR TITLE
feat: add restaurant chat agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_MISTRAL_API_KEY=your_api_key_here

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
-REACT_APP_MISTRAL_API_KEY=your_api_key_here
+# Mistral API key — used by the worker proxy only, never exposed to the browser
+MISTRAL_API_KEY=your_mistral_api_key_here

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,6 +23,8 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+        env:
+          REACT_APP_MISTRAL_API_KEY: ${{ secrets.REACT_APP_MISTRAL_API_KEY }}
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          REACT_APP_MISTRAL_API_KEY: ${{ secrets.REACT_APP_MISTRAL_API_KEY }}
+          REACT_APP_CHAT_API_URL: ${{ secrets.REACT_APP_CHAT_API_URL }}
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ yarn-debug.log*
 yarn-error.log*
 
 .env
+
+# worker secrets
+worker/.dev.vars
+worker/.wrangler/

--- a/.kiro/specs/restaurant-chat-agent/.config.kiro
+++ b/.kiro/specs/restaurant-chat-agent/.config.kiro
@@ -1,0 +1,1 @@
+{"generationMode": "requirements-first"}

--- a/.kiro/specs/restaurant-chat-agent/design.md
+++ b/.kiro/specs/restaurant-chat-agent/design.md
@@ -1,0 +1,65 @@
+# Design: Restaurant Chat Agent
+
+## Overview
+
+Floating Mistral-powered chat widget on city pages. Frontend calls Mistral API directly (no backend). Restaurant data injected via system prompt. Conversation state in React state, resets on navigation.
+
+### Key Decisions
+
+- Direct frontend API calls (acceptable for side project, key via env var)
+- Full restaurant dataset serialized into system prompt
+- No streaming (simple request/response)
+- Session-scoped state (resets on navigation)
+
+## Architecture
+
+```
+City.tsx
+└── ChatWidget (isOpen state)
+    ├── ChatButton (floating FAB, bottom-right)
+    └── ChatPanel
+        ├── Header (title + close)
+        ├── Messages (scrollable, auto-scroll)
+        ├── Loading indicator (3-dot animation)
+        └── ChatInput (text + send button)
+```
+
+## Interfaces
+
+```typescript
+// ChatWidget — top-level, rendered in City.tsx
+interface ChatWidgetProps { cityName: string; foodPlaces: FoodPlace[]; }
+
+// ChatPanel — expanded chat UI
+interface ChatPanelProps { cityName: string; foodPlaces: FoodPlace[]; onClose: () => void; }
+
+// ChatInput — text input + send
+interface ChatInputProps { onSend: (message: string) => void; disabled: boolean; }
+
+// ChatMessage — aligns with Mistral API format
+interface ChatMessage { role: 'user' | 'assistant' | 'system'; content: string; }
+```
+
+## Services
+
+`buildSystemPrompt(cityName, foodPlaces)` — serializes restaurant data into a constraining system prompt.
+
+`sendMessage(messages, apiKey)` — POSTs to `https://api.mistral.ai/v1/chat/completions` with `mistral-small-latest`. Throws on non-2xx.
+
+## Error Handling
+
+| Scenario | Handling |
+|---|---|
+| API error / network failure | Error message in chat, input stays enabled |
+| Missing API key | "Chat unavailable" message, input disabled |
+| Empty input | Rejected at ChatInput level |
+| Malformed response | Generic error message in chat |
+
+## Correctness Properties
+
+1. `buildSystemPrompt` output contains every restaurant's name, price, cuisines, neighborhood — **Validates: 3.1**
+2. API request starts with system message, followed by history in order — **Validates: 2.1, 4.1, 6.3**
+3. Whitespace-only input is rejected — **Validates: 2.5**
+4. Welcome message contains city name — **Validates: 1.5**
+5. User/assistant messages appear in conversation history — **Validates: 2.2, 2.4**
+6. API errors produce error messages in history — **Validates: 5.1**

--- a/.kiro/specs/restaurant-chat-agent/requirements.md
+++ b/.kiro/specs/restaurant-chat-agent/requirements.md
@@ -1,0 +1,61 @@
+# Requirements: Restaurant Chat Agent
+
+Floating AI chat widget on city pages. Powered by Mistral AI, recommends restaurants exclusively from the app's existing `FoodPlace` data for the selected city.
+
+## Glossary
+
+- **Chat_Widget**: Floating button + expandable chat panel on city pages
+- **Chat_Agent**: Mistral-powered conversational system for restaurant recommendations
+- **Restaurant_Data**: `FoodPlace[]` loaded from city JSON files
+- **System_Prompt**: Instruction sent to Mistral containing serialized restaurant data
+
+## Requirements
+
+### 1. Chat Widget on City Pages
+
+As a user browsing a city page, I want a floating chat button to access the restaurant recommendation agent.
+
+- 1.1 Floating button renders bottom-right on city pages
+- 1.2 Clicking expands into a chat panel with conversation history and text input
+- 1.3 Close button collapses back to floating button
+- 1.4 Panel stays visible while scrolling
+- 1.5 Welcome message on first open includes city name
+
+### 2. Send Messages and Receive Responses
+
+As a user, I want to type a message and get restaurant recommendations matching my preferences.
+
+- 2.1 Enter/send button submits message with conversation history and system prompt to Mistral
+- 2.2 User message appears in history immediately
+- 2.3 Loading indicator shown during API request
+- 2.4 Agent response appears in history when received
+- 2.5 Empty/whitespace-only messages are rejected
+
+### 3. Constrain to City Restaurant Data
+
+As a user, I want recommendations only from the app's data for the current city.
+
+- 3.1 System prompt includes all restaurant data (name, description, price, cuisines, neighborhood)
+- 3.2 System prompt instructs agent to only recommend listed restaurants
+- 3.3 Agent references actual restaurant names, prices, neighborhoods from the data
+- 3.4 Agent says "no match" and suggests broadening criteria when nothing fits
+
+### 4. Conversation Context
+
+As a user, I want multi-turn dialogue with the agent.
+
+- 4.1 Follow-up messages include full conversation history in API request
+- 4.2 History resets when navigating away from city page
+- 4.3 History resets when switching cities
+
+### 5. Error Handling
+
+- 5.1 API failures show error message in chat history
+- 5.2 User can continue sending messages after an error
+- 5.3 Missing API key shows "chat unavailable" message
+
+### 6. API Configuration
+
+- 6.1 API key read from `REACT_APP_MISTRAL_API_KEY` env var
+- 6.2 Uses Mistral chat completion endpoint
+- 6.3 System prompt sent as first message with role "system"

--- a/.kiro/specs/restaurant-chat-agent/tasks.md
+++ b/.kiro/specs/restaurant-chat-agent/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Restaurant Chat Agent
+
+## Tasks
+
+- [x] 1. Setup
+  - [x] 1.1 Create `.env.example` with `REACT_APP_MISTRAL_API_KEY` placeholder
+
+- [x] 2. Service layer
+  - [x] 2.1 Create `src/api/buildSystemPrompt.ts` — serialize restaurant data into constraining prompt
+  - [x] 2.2 Create `src/api/MistralService.ts` — `sendMessage()` POSTs to Mistral API
+
+- [x] 3. Data model
+  - [x] 3.1 Create `src/model/ChatMessage.ts` — interface, `isValidMessage()`, `buildWelcomeMessage()`
+
+- [x] 4. ChatInput component
+  - [x] 4.1 Create `src/components/Chat/ChatInput.tsx` + SCSS
+
+- [x] 5. ChatPanel component
+  - [x] 5.1 Create `src/components/Chat/ChatPanel.tsx` + SCSS
+
+- [x] 6. Widget components
+  - [x] 6.1 Create `src/components/Chat/ChatButton.tsx` + SCSS — floating FAB
+  - [x] 6.2 Create `src/components/Chat/ChatWidget.tsx` — manages open/closed state
+
+- [x] 7. Integration
+  - [x] 7.1 Add `ChatWidget` to `City.tsx` inside `LoadData` render prop
+
+## Notes
+
+- API key from `REACT_APP_MISTRAL_API_KEY` env var

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,17 @@ services:
     volumes:
       - './src:/app/src'
       - './public:/app/public'
-    env_file:
-      - .env
     environment:
       - CHOKIDAR_USEPOLLING=true
+      - REACT_APP_CHAT_API_URL=http://localhost:8787
+    depends_on:
+      - worker
+
+  worker:
+    build: ./worker
+    command: ["node", "src/local-proxy.js"]
+    ports:
+      - "8787:8787"
+    volumes:
+      - './worker/src:/app/src'
+      - './worker/.dev.vars:/app/.dev.vars'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,13 @@ version: '2.4'
 
 services:
   the-culinary-passport:
-    image: the-culinary-passport
+    build: .
     ports:
       - "3000:3000"
     volumes:
-      - './public/data_paris.json:/app/public/data_paris.json'
-      - './public/data_montreal.json:/app/public/data_montreal.json'
+      - './src:/app/src'
+      - './public:/app/public'
+    env_file:
+      - .env
+    environment:
+      - CHOKIDAR_USEPOLLING=true

--- a/src/api/MistralService.ts
+++ b/src/api/MistralService.ts
@@ -1,14 +1,12 @@
 /**
- * Service module for communicating with the Mistral AI chat completion API.
- *
- * Requirements: 6.1, 6.2, 6.3, 2.1
+ * Service module for communicating with the Mistral AI via Cloudflare Worker proxy.
  */
 
 import { ChatMessage } from 'model/ChatMessage';
 
 export type { ChatMessage };
 
-const MISTRAL_API_URL = 'https://api.mistral.ai/v1/chat/completions';
+const API_URL = process.env.REACT_APP_CHAT_API_URL || '';
 
 interface MistralChatResponse {
   choices: Array<{
@@ -20,23 +18,22 @@ interface MistralChatResponse {
 }
 
 export async function sendMessage(
-  messages: ChatMessage[],
-  apiKey: string
+  messages: ChatMessage[]
 ): Promise<string> {
-  const response = await fetch(MISTRAL_API_URL, {
+  if (!API_URL) {
+    throw new Error('Chat API URL not configured');
+  }
+
+  const response = await fetch(API_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
     },
-    body: JSON.stringify({
-      model: 'mistral-small-latest',
-      messages,
-    }),
+    body: JSON.stringify({ messages }),
   });
 
   if (!response.ok) {
-    throw new Error(`Mistral API error: ${response.status}`);
+    throw new Error(`Chat API error: ${response.status}`);
   }
 
   const data: MistralChatResponse = await response.json();

--- a/src/api/MistralService.ts
+++ b/src/api/MistralService.ts
@@ -1,0 +1,44 @@
+/**
+ * Service module for communicating with the Mistral AI chat completion API.
+ *
+ * Requirements: 6.1, 6.2, 6.3, 2.1
+ */
+
+import { ChatMessage } from 'model/ChatMessage';
+
+export type { ChatMessage };
+
+const MISTRAL_API_URL = 'https://api.mistral.ai/v1/chat/completions';
+
+interface MistralChatResponse {
+  choices: Array<{
+    message: {
+      role: string;
+      content: string;
+    };
+  }>;
+}
+
+export async function sendMessage(
+  messages: ChatMessage[],
+  apiKey: string
+): Promise<string> {
+  const response = await fetch(MISTRAL_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'mistral-small-latest',
+      messages,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Mistral API error: ${response.status}`);
+  }
+
+  const data: MistralChatResponse = await response.json();
+  return data.choices[0].message.content;
+}

--- a/src/api/buildSystemPrompt.ts
+++ b/src/api/buildSystemPrompt.ts
@@ -1,0 +1,12 @@
+import FoodPlace from "model/FoodPlace";
+
+export function buildSystemPrompt(cityName: string, foodPlaces: FoodPlace[]): string {
+  const restaurantList = foodPlaces.map(fp =>
+    `- ${fp.name} | Price: ${fp.price} | Cuisine: ${fp.typeOfCuisine.join(', ')} | Neighborhood: ${fp.neighborhood || 'N/A'} | Description: ${fp.description}`
+  ).join('\n');
+
+  return `You are a friendly restaurant recommendation assistant for ${cityName}. ` +
+    `You ONLY recommend restaurants from the following list. Do NOT suggest any restaurant not on this list. ` +
+    `If no restaurants match the user's request, say so and suggest they broaden their criteria.\n\n` +
+    `Available restaurants in ${cityName}:\n${restaurantList}`;
+}

--- a/src/api/buildSystemPrompt.ts
+++ b/src/api/buildSystemPrompt.ts
@@ -8,5 +8,10 @@ export function buildSystemPrompt(cityName: string, foodPlaces: FoodPlace[]): st
   return `You are a friendly restaurant recommendation assistant for ${cityName}. ` +
     `You ONLY recommend restaurants from the following list. Do NOT suggest any restaurant not on this list. ` +
     `If no restaurants match the user's request, say so and suggest they broaden their criteria.\n\n` +
+    `Format your responses using Markdown:\n` +
+    `- Use **bold** for restaurant names\n` +
+    `- Use bullet points when listing multiple restaurants\n` +
+    `- Include neighborhood, price range, and cuisine type for each recommendation\n` +
+    `- Keep responses concise and well-structured\n\n` +
     `Available restaurants in ${cityName}:\n${restaurantList}`;
 }

--- a/src/components/Chat/ChatButton.scss
+++ b/src/components/Chat/ChatButton.scss
@@ -1,0 +1,23 @@
+.chat-button {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 56px;
+  height: 56px;
+  border: none;
+  border-radius: 50%;
+  background-color: var(--color-primary-4);
+  color: white;
+  font-size: 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: var(--color-primary-5);
+  }
+}

--- a/src/components/Chat/ChatButton.tsx
+++ b/src/components/Chat/ChatButton.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faComments } from "@fortawesome/free-solid-svg-icons";
+import "./ChatButton.scss";
+
+interface ChatButtonProps {
+  onClick: () => void;
+}
+
+const ChatButton: React.FC<ChatButtonProps> = ({ onClick }) => {
+  return (
+    <button className="chat-button" onClick={onClick} aria-label="Open chat">
+      <FontAwesomeIcon icon={faComments} />
+    </button>
+  );
+};
+
+export default ChatButton;

--- a/src/components/Chat/ChatInput.scss
+++ b/src/components/Chat/ChatInput.scss
@@ -1,0 +1,50 @@
+.chat-input {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid var(--color-light-grey);
+}
+
+.chat-input-field {
+  flex: 1;
+  padding: 10px 12px;
+  border: 1px solid var(--color-light-grey);
+  border-radius: 20px;
+  font-size: 14px;
+  outline: none;
+  font-family: inherit;
+
+  &:focus {
+    border-color: var(--color-primary-4);
+  }
+
+  &:disabled {
+    background-color: var(--color-light-grey);
+    cursor: not-allowed;
+  }
+}
+
+.chat-send-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 50%;
+  background-color: var(--color-primary-4);
+  color: white;
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 14px;
+
+  &:hover:not(:disabled) {
+    background-color: var(--color-primary-5);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
+import { isValidMessage } from "model/ChatMessage";
+import "./ChatInput.scss";
+
+interface ChatInputProps {
+  onSend: (message: string) => void;
+  disabled: boolean;
+}
+
+const ChatInput: React.FC<ChatInputProps> = ({ onSend, disabled }) => {
+  const [input, setInput] = useState("");
+
+  const handleSend = () => {
+    if (!isValidMessage(input) || disabled) return;
+    onSend(input);
+    setInput("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="chat-input">
+      <input
+        type="text"
+        className="chat-input-field"
+        placeholder="Ask about restaurants..."
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+      />
+      <button
+        className="chat-send-button"
+        onClick={handleSend}
+        disabled={disabled || !isValidMessage(input)}
+        aria-label="Send message"
+      >
+        <FontAwesomeIcon icon={faPaperPlane} />
+      </button>
+    </div>
+  );
+};
+
+export default ChatInput;

--- a/src/components/Chat/ChatPanel.scss
+++ b/src/components/Chat/ChatPanel.scss
@@ -1,0 +1,128 @@
+.chat-panel {
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  height: 520px;
+  background-color: var(--bg);
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 1000;
+}
+
+.chat-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  background-color: var(--color-primary-4);
+  color: white;
+}
+
+.chat-panel-title {
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.chat-panel-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: white;
+  cursor: pointer;
+  font-size: 16px;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+}
+
+.chat-panel-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.chat-message {
+  max-width: 80%;
+  padding: 10px 14px;
+  border-radius: 16px;
+  font-size: 14px;
+  line-height: 1.4;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.chat-message--user {
+  align-self: flex-end;
+  background-color: var(--color-primary-4);
+  color: white;
+  border-bottom-right-radius: 4px;
+}
+
+.chat-message--assistant {
+  align-self: flex-start;
+  background-color: var(--color-light-grey);
+  color: var(--fg);
+  border-bottom-left-radius: 4px;
+}
+
+.chat-unavailable {
+  text-align: center;
+  padding: 16px;
+  color: var(--color-primary-3);
+  font-size: 14px;
+  font-style: italic;
+}
+
+.chat-typing-indicator {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 12px 16px;
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--fg);
+    opacity: 0.4;
+    animation: typing-bounce 1.4s infinite ease-in-out both;
+
+    &:nth-child(1) {
+      animation-delay: 0s;
+    }
+
+    &:nth-child(2) {
+      animation-delay: 0.2s;
+    }
+
+    &:nth-child(3) {
+      animation-delay: 0.4s;
+    }
+  }
+}
+
+@keyframes typing-bounce {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.6);
+    opacity: 0.4;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/src/components/Chat/ChatPanel.scss
+++ b/src/components/Chat/ChatPanel.scss
@@ -61,7 +61,19 @@
   font-size: 14px;
   line-height: 1.4;
   word-wrap: break-word;
-  white-space: pre-wrap;
+
+  p {
+    margin: 4px 0;
+  }
+
+  ul {
+    margin: 4px 0;
+    padding-left: 18px;
+  }
+
+  li {
+    margin: 2px 0;
+  }
 }
 
 .chat-message--user {

--- a/src/components/Chat/ChatPanel.tsx
+++ b/src/components/Chat/ChatPanel.tsx
@@ -1,0 +1,93 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
+import { ChatMessage, buildWelcomeMessage } from "model/ChatMessage";
+import { sendMessage } from "api/MistralService";
+import { buildSystemPrompt } from "api/buildSystemPrompt";
+import ChatInput from "components/Chat/ChatInput";
+import { formatMessage } from "components/Chat/formatMessage";
+import FoodPlace from "model/FoodPlace";
+import "./ChatPanel.scss";
+
+interface ChatPanelProps {
+  cityName: string;
+  foodPlaces: FoodPlace[];
+  onClose: () => void;
+}
+
+const ChatPanel: React.FC<ChatPanelProps> = ({ cityName, foodPlaces, onClose }) => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const apiKey = process.env.REACT_APP_MISTRAL_API_KEY;
+  const isAvailable = Boolean(apiKey);
+
+  useEffect(() => {
+    setMessages([buildWelcomeMessage(cityName)]);
+  }, [cityName]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, isLoading]);
+
+  const handleSend = useCallback(async (content: string) => {
+    const userMessage: ChatMessage = { role: "user", content };
+    setMessages((prev) => [...prev, userMessage]);
+    setIsLoading(true);
+
+    try {
+      const systemPrompt = buildSystemPrompt(cityName, foodPlaces);
+      const systemMessage: ChatMessage = { role: "system", content: systemPrompt };
+      const apiMessages = [systemMessage, ...messages, userMessage];
+
+      const response = await sendMessage(apiMessages, apiKey!);
+      const assistantMessage: ChatMessage = { role: "assistant", content: response };
+      setMessages((prev) => [...prev, assistantMessage]);
+    } catch {
+      const errorMessage: ChatMessage = {
+        role: "assistant",
+        content: "Sorry, I couldn't process your request. Please try again.",
+      };
+      setMessages((prev) => [...prev, errorMessage]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [cityName, foodPlaces, apiKey, messages]);
+
+  return (
+    <div className="chat-panel">
+      <div className="chat-panel-header">
+        <span className="chat-panel-title">Restaurant Guide</span>
+        <button className="chat-panel-close" onClick={onClose} aria-label="Close chat">
+          <FontAwesomeIcon icon={faTimes} />
+        </button>
+      </div>
+
+      <div className="chat-panel-messages">
+        {!isAvailable && (
+          <div className="chat-unavailable">
+            Chat is currently unavailable. Please configure the API key.
+          </div>
+        )}
+        {messages.map((msg, index) => (
+          <div key={index} className={`chat-message chat-message--${msg.role}`}>
+            {formatMessage(msg.content)}
+          </div>
+        ))}
+        {isLoading && (
+          <div className="chat-message chat-message--assistant chat-typing-indicator">
+            <span className="dot" />
+            <span className="dot" />
+            <span className="dot" />
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <ChatInput onSend={handleSend} disabled={!isAvailable || isLoading} />
+    </div>
+  );
+};
+
+export default ChatPanel;

--- a/src/components/Chat/ChatPanel.tsx
+++ b/src/components/Chat/ChatPanel.tsx
@@ -20,8 +20,8 @@ const ChatPanel: React.FC<ChatPanelProps> = ({ cityName, foodPlaces, onClose }) 
   const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const apiKey = process.env.REACT_APP_MISTRAL_API_KEY;
-  const isAvailable = Boolean(apiKey);
+  const apiUrl = process.env.REACT_APP_CHAT_API_URL;
+  const isAvailable = Boolean(apiUrl);
 
   useEffect(() => {
     setMessages([buildWelcomeMessage(cityName)]);
@@ -41,7 +41,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({ cityName, foodPlaces, onClose }) 
       const systemMessage: ChatMessage = { role: "system", content: systemPrompt };
       const apiMessages = [systemMessage, ...messages, userMessage];
 
-      const response = await sendMessage(apiMessages, apiKey!);
+      const response = await sendMessage(apiMessages);
       const assistantMessage: ChatMessage = { role: "assistant", content: response };
       setMessages((prev) => [...prev, assistantMessage]);
     } catch {
@@ -53,7 +53,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({ cityName, foodPlaces, onClose }) 
     } finally {
       setIsLoading(false);
     }
-  }, [cityName, foodPlaces, apiKey, messages]);
+  }, [cityName, foodPlaces, messages]);
 
   return (
     <div className="chat-panel">
@@ -67,7 +67,7 @@ const ChatPanel: React.FC<ChatPanelProps> = ({ cityName, foodPlaces, onClose }) 
       <div className="chat-panel-messages">
         {!isAvailable && (
           <div className="chat-unavailable">
-            Chat is currently unavailable. Please configure the API key.
+            Chat is currently unavailable. Please try again later.
           </div>
         )}
         {messages.map((msg, index) => (

--- a/src/components/Chat/ChatWidget.scss
+++ b/src/components/Chat/ChatWidget.scss
@@ -1,0 +1,1 @@
+/* ChatWidget styles are handled by ChatButton.scss and ChatPanel.scss */

--- a/src/components/Chat/ChatWidget.tsx
+++ b/src/components/Chat/ChatWidget.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from "react";
+import ChatButton from "components/Chat/ChatButton";
+import ChatPanel from "components/Chat/ChatPanel";
+import FoodPlace from "model/FoodPlace";
+
+interface ChatWidgetProps {
+  cityName: string;
+  foodPlaces: FoodPlace[];
+}
+
+const ChatWidget: React.FC<ChatWidgetProps> = ({ cityName, foodPlaces }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (isOpen) {
+    return (
+      <ChatPanel
+        cityName={cityName}
+        foodPlaces={foodPlaces}
+        onClose={() => setIsOpen(false)}
+      />
+    );
+  }
+
+  return <ChatButton onClick={() => setIsOpen(true)} />;
+};
+
+export default ChatWidget;

--- a/src/components/Chat/formatMessage.tsx
+++ b/src/components/Chat/formatMessage.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 
 /**
- * Lightweight inline Markdown renderer for chat messages.
- * Handles: **bold**, *italic*, and line breaks.
+ * Lightweight Markdown renderer for chat messages.
+ * Handles: **bold**, *italic*, bullet lists (- or *), and line breaks.
  */
-export function formatMessage(text: string): React.ReactNode[] {
+
+function renderInline(text: string, keyPrefix: string): React.ReactNode[] {
   const parts: React.ReactNode[] = [];
   const regex = /(\*\*(.+?)\*\*|\*(.+?)\*)/g;
   let lastIndex = 0;
@@ -15,9 +16,9 @@ export function formatMessage(text: string): React.ReactNode[] {
       parts.push(text.slice(lastIndex, match.index));
     }
     if (match[2]) {
-      parts.push(<strong key={match.index}>{match[2]}</strong>);
+      parts.push(<strong key={`${keyPrefix}-b-${match.index}`}>{match[2]}</strong>);
     } else if (match[3]) {
-      parts.push(<em key={match.index}>{match[3]}</em>);
+      parts.push(<em key={`${keyPrefix}-i-${match.index}`}>{match[3]}</em>);
     }
     lastIndex = regex.lastIndex;
   }
@@ -27,4 +28,46 @@ export function formatMessage(text: string): React.ReactNode[] {
   }
 
   return parts;
+}
+
+export function formatMessage(text: string): React.ReactNode {
+  const lines = text.split("\n");
+  const elements: React.ReactNode[] = [];
+  let currentList: React.ReactNode[] = [];
+
+  const flushList = () => {
+    if (currentList.length > 0) {
+      elements.push(<ul key={`ul-${elements.length}`}>{currentList}</ul>);
+      currentList = [];
+    }
+  };
+
+  lines.forEach((line, i) => {
+    const trimmed = line.trim();
+
+    // Bullet list item: starts with "- " or "* "
+    const listMatch = trimmed.match(/^[-*]\s+(.+)/);
+    if (listMatch) {
+      currentList.push(
+        <li key={`li-${i}`}>{renderInline(listMatch[1], `li-${i}`)}</li>
+      );
+      return;
+    }
+
+    flushList();
+
+    if (trimmed === "") {
+      return; // skip empty lines
+    }
+
+    elements.push(
+      <p key={`p-${i}`} style={{ margin: "4px 0" }}>
+        {renderInline(trimmed, `p-${i}`)}
+      </p>
+    );
+  });
+
+  flushList();
+
+  return <>{elements}</>;
 }

--- a/src/components/Chat/formatMessage.tsx
+++ b/src/components/Chat/formatMessage.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+/**
+ * Lightweight inline Markdown renderer for chat messages.
+ * Handles: **bold**, *italic*, and line breaks.
+ */
+export function formatMessage(text: string): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  const regex = /(\*\*(.+?)\*\*|\*(.+?)\*)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    if (match[2]) {
+      parts.push(<strong key={match.index}>{match[2]}</strong>);
+    } else if (match[3]) {
+      parts.push(<em key={match.index}>{match[3]}</em>);
+    }
+    lastIndex = regex.lastIndex;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts;
+}

--- a/src/components/City/City.tsx
+++ b/src/components/City/City.tsx
@@ -11,6 +11,7 @@ import Map from "components/Map/Map";
 import ToastList from "components/ToastNotification/List/ToastList";
 import { useToastNotifications } from "hooks/useToastNotifications";
 import { POSITION } from "components/ToastNotification/constants";
+import ChatWidget from "components/Chat/ChatWidget";
 import "./City.scss";
 
 interface ICityProps {
@@ -85,6 +86,7 @@ const City: React.FC<ICityProps> = (props) => {
                                 />
                             )}
                         </SideSheet>
+                        <ChatWidget cityName={props.city.name} foodPlaces={foodPlaceList} />
                     </>
                 )}
             </LoadData>

--- a/src/model/ChatMessage.ts
+++ b/src/model/ChatMessage.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared ChatMessage type and message utilities.
+ *
+ * Requirements: 2.5, 1.5
+ */
+
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+/**
+ * Returns true if the input is a non-empty, non-whitespace-only string.
+ * Rejects empty strings and strings composed entirely of whitespace.
+ */
+export function isValidMessage(input: string): boolean {
+  return input.trim().length > 0;
+}
+
+/**
+ * Builds a welcome message for the chat panel, containing the city name.
+ */
+export function buildWelcomeMessage(cityName: string): ChatMessage {
+  return {
+    role: 'assistant',
+    content: `Welcome! I'm your restaurant guide for ${cityName}. Ask me about restaurants, cuisines, or neighborhoods and I'll recommend places from our curated list. What are you in the mood for?`,
+  };
+}

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-slim
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+CMD ["node", "src/local-proxy.js"]

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "culinary-passport-api",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.0.0",
+    "@cloudflare/workers-types": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,67 @@
+interface Env {
+  MISTRAL_API_KEY: string;
+  ALLOWED_ORIGIN: string;
+}
+
+const MISTRAL_API_URL = "https://api.mistral.ai/v1/chat/completions";
+
+function corsHeaders(origin: string, allowedOrigin: string): Record<string, string> {
+  const isAllowed = origin === allowedOrigin || allowedOrigin === "*";
+  return {
+    "Access-Control-Allow-Origin": isAllowed ? origin : "",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const origin = request.headers.get("Origin") || "";
+    const headers = corsHeaders(origin, env.ALLOWED_ORIGIN);
+
+    // Handle CORS preflight
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers });
+    }
+
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405, headers });
+    }
+
+    try {
+      const body = await request.json() as { messages: unknown[] };
+
+      if (!body.messages || !Array.isArray(body.messages)) {
+        return new Response(
+          JSON.stringify({ error: "messages array is required" }),
+          { status: 400, headers: { ...headers, "Content-Type": "application/json" } }
+        );
+      }
+
+      const mistralResponse = await fetch(MISTRAL_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${env.MISTRAL_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: "mistral-small-latest",
+          messages: body.messages,
+        }),
+      });
+
+      const data = await mistralResponse.text();
+
+      return new Response(data, {
+        status: mistralResponse.status,
+        headers: { ...headers, "Content-Type": "application/json" },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      return new Response(
+        JSON.stringify({ error: message }),
+        { status: 500, headers: { ...headers, "Content-Type": "application/json" } }
+      );
+    }
+  },
+};

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4,6 +4,24 @@ interface Env {
 }
 
 const MISTRAL_API_URL = "https://api.mistral.ai/v1/chat/completions";
+const RATE_LIMIT = 10; // max requests per IP per window
+const RATE_WINDOW_MS = 60_000; // 1 minute
+
+// In-memory rate limiter (resets on cold start, good enough for side project)
+const ipCounts = new Map<string, { count: number; resetAt: number }>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = ipCounts.get(ip);
+
+  if (!entry || now > entry.resetAt) {
+    ipCounts.set(ip, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return false;
+  }
+
+  entry.count++;
+  return entry.count > RATE_LIMIT;
+}
 
 function corsHeaders(origin: string, allowedOrigin: string): Record<string, string> {
   const isAllowed = origin === allowedOrigin || allowedOrigin === "*";
@@ -19,13 +37,21 @@ export default {
     const origin = request.headers.get("Origin") || "";
     const headers = corsHeaders(origin, env.ALLOWED_ORIGIN);
 
-    // Handle CORS preflight
     if (request.method === "OPTIONS") {
       return new Response(null, { status: 204, headers });
     }
 
     if (request.method !== "POST") {
       return new Response("Method not allowed", { status: 405, headers });
+    }
+
+    // Rate limit by IP
+    const ip = request.headers.get("CF-Connecting-IP") || "unknown";
+    if (isRateLimited(ip)) {
+      return new Response(
+        JSON.stringify({ error: "Too many requests. Please wait a moment." }),
+        { status: 429, headers: { ...headers, "Content-Type": "application/json" } }
+      );
     }
 
     try {

--- a/worker/src/local-proxy.js
+++ b/worker/src/local-proxy.js
@@ -1,0 +1,78 @@
+const http = require("http");
+const https = require("https");
+const fs = require("fs");
+const path = require("path");
+
+// Load .dev.vars
+const vars = {};
+try {
+  const content = fs.readFileSync(path.join(__dirname, "..", ".dev.vars"), "utf8");
+  content.split("\n").forEach((line) => {
+    const [key, ...rest] = line.split("=");
+    if (key && rest.length) vars[key.trim()] = rest.join("=").trim();
+  });
+} catch {}
+
+const MISTRAL_API_KEY = vars.MISTRAL_API_KEY || process.env.MISTRAL_API_KEY;
+const PORT = process.env.PORT || 8787;
+
+const server = http.createServer((req, res) => {
+  // CORS
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204);
+    return res.end();
+  }
+
+  if (req.method !== "POST") {
+    res.writeHead(405, { "Content-Type": "application/json" });
+    return res.end(JSON.stringify({ error: "Method not allowed" }));
+  }
+
+  let body = "";
+  req.on("data", (chunk) => (body += chunk));
+  req.on("end", () => {
+    try {
+      const { messages } = JSON.parse(body);
+      if (!messages || !Array.isArray(messages)) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        return res.end(JSON.stringify({ error: "messages array required" }));
+      }
+
+      const payload = JSON.stringify({ model: "mistral-small-latest", messages });
+      const options = {
+        hostname: "api.mistral.ai",
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${MISTRAL_API_KEY}`,
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      };
+
+      const apiReq = https.request(options, (apiRes) => {
+        res.writeHead(apiRes.statusCode, { "Content-Type": "application/json" });
+        apiRes.pipe(res);
+      });
+
+      apiReq.on("error", (err) => {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: err.message }));
+      });
+
+      apiReq.write(payload);
+      apiReq.end();
+    } catch (err) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: err.message }));
+    }
+  });
+});
+
+server.listen(PORT, "0.0.0.0", () => {
+  console.log(`Proxy listening on http://0.0.0.0:${PORT}`);
+});

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "lib": ["ES2021"],
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"]
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,10 @@
+name = "culinary-passport-api"
+main = "src/index.ts"
+compatibility_date = "2024-09-23"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+ALLOWED_ORIGIN = "https://kimanhou.github.io"
+
+[env.production.vars]
+ALLOWED_ORIGIN = "https://kimanhou.github.io"


### PR DESCRIPTION
## What

Adds a floating chat widget on city pages powered by Mistral AI that recommends restaurants from the app's existing curated data. The Mistral API key is kept server-side via a Cloudflare Worker proxy — no secrets in the browser bundle.

## How it works

1. User opens a city page → floating chat button appears bottom-right
2. User clicks → chat panel opens with a welcome message
3. User types a question → frontend sends the message to the Cloudflare Worker
4. Worker adds the Mistral API key and forwards to Mistral's chat completion API
5. Response comes back through the worker → rendered in the chat with Markdown formatting

## Architecture: Cloudflare Worker proxy

```
Browser (GitHub Pages)          Cloudflare Worker              Mistral API
─────────────────────          ──────────────────              ───────────
POST /                    →    Adds Authorization header  →   POST /v1/chat/completions
{ messages: [...] }            Bearer <MISTRAL_API_KEY>       { model, messages }
                          ←    Forwards response          ←   { choices: [...] }
```

The frontend only knows the worker URL. It never sees or sends the Mistral API key.

## Security model

| Layer | Protection |
|---|---|
| API key storage | Stored as a Cloudflare Worker encrypted secret (write-only, not readable from dashboard or code) |
| Browser bundle | Contains only the worker URL (`REACT_APP_CHAT_API_URL`), no API keys |
| CORS | Worker only accepts requests from `https://kimanhou.github.io` — browsers from other origins are blocked |
| Rate limiting | In-memory per-IP rate limiter: 10 requests/minute per IP. Returns 429 if exceeded |
| Budget cap | Mistral account has a $10/month budget limit as a last line of defense |
| Secrets in repo | `.env` and `worker/.dev.vars` are in `.gitignore`, never committed |

**Known limitations:**
- CORS only blocks browsers, not curl/scripts. The rate limiter + budget cap cover this.
- The in-memory rate limiter resets on worker cold starts (acceptable for a side project).
- The worker URL is public (visible in the JS bundle), but without the API key it's just a proxy endpoint.

## Changes

### Cloudflare Worker (`worker/`)
- `src/index.ts` — production worker: CORS, rate limiting, Mistral proxy
- `src/local-proxy.js` — simple Node.js proxy for local Docker dev
- `wrangler.toml` — worker config with ALLOWED_ORIGIN
- `Dockerfile` — for local dev via docker-compose

### Frontend
- `src/api/MistralService.ts` — calls worker URL instead of Mistral directly, no API key param
- `src/api/buildSystemPrompt.ts` — serializes restaurant data, instructs Mistral to use Markdown
- `src/model/ChatMessage.ts` — shared types and utilities
- `src/components/Chat/*` — ChatInput, ChatPanel, ChatButton, ChatWidget, formatMessage
- `src/components/City/City.tsx` — renders ChatWidget inside LoadData

### Config
- `docker-compose.yml` — adds worker service for local dev
- `.github/workflows/ci-cd.yml` — uses `REACT_APP_CHAT_API_URL` secret (not API key)
- `.gitignore` — excludes `.env`, `worker/.dev.vars`, `worker/.wrangler/`
- `.env.example` — documents required env vars

## Spec

See `.kiro/specs/restaurant-chat-agent/` for requirements, design, and task list.
